### PR TITLE
Remove unused `--aws-provider-name` argument

### DIFF
--- a/src/pubtools/_adc/tasks/base.py
+++ b/src/pubtools/_adc/tasks/base.py
@@ -70,12 +70,6 @@ class AmiBase(AmiTask, AWSPublishService, CollectorService):
         )
 
         group.add_argument(
-            "--aws-provider-name",
-            help="AWS provider e.g. AWS, ACN (AWS China), AGOV (AWS US Gov)",
-            default="AWS",
-        )
-
-        group.add_argument(
             "--retry-wait",
             help="duration to wait in sec before retrying action on AWS",
             type=int,

--- a/tests/push/test_ami_push.py
+++ b/tests/push/test_ami_push.py
@@ -172,8 +172,6 @@ def test_do_push(command_tester, requests_mocker, mock_aws_publish, fake_collect
         lambda: entry_point(ADCPush),
         [
             "test-push",
-            "--aws-provider-name",
-            "awstest",
             "--retry-wait",
             "1",
             "--accounts",
@@ -249,8 +247,6 @@ def test_no_aws_credentials(command_tester):
         [
             "test-push",
             "--debug",
-            "--aws-provider-name",
-            "awstest",
             "--accounts",
             accounts,
             "--snapshot-account-ids",
@@ -270,8 +266,6 @@ def test_push_public_image(
         lambda: entry_point(ADCPush),
         [
             "test-push",
-            "--aws-provider-name",
-            "awstest",
             "--retry-wait",
             "1",
             "--accounts",
@@ -339,8 +333,6 @@ def test_not_ami_push_item(command_tester, staged_file):
         lambda: entry_point(ADCPush),
         [
             "test-push",
-            "--aws-provider-name",
-            "awstest",
             "--retry-wait",
             "1",
             "--max-retries",
@@ -374,8 +366,6 @@ def test_aws_publish_failure_retry(
         lambda: entry_point(ADCPush),
         [
             "test-push",
-            "--aws-provider-name",
-            "awstest",
             "--retry-wait",
             "1",
             "--accounts",
@@ -449,8 +439,6 @@ def test_publish_retry_multiple(command_tester, mock_region_data, mock_ami_uploa
         lambda: entry_point(ADCPush),
         [
             "test-push",
-            "--aws-provider-name",
-            "awstest",
             "--retry-wait",
             "1",
             "--accounts",


### PR DESCRIPTION
Remove unused `--aws-provider-name` argument which was a leftover piece of code from RHSM.